### PR TITLE
refactored to use specific stereotype annotations & more

### DIFF
--- a/src/main/java/com/learningadventures/learnspringframework/examples/a2/LazyIntializationLauncherApplication.java
+++ b/src/main/java/com/learningadventures/learnspringframework/examples/a2/LazyIntializationLauncherApplication.java
@@ -1,0 +1,52 @@
+package com.learningadventures.learnspringframework.examples.a2;
+
+import java.util.Arrays;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+class ClassA {
+
+}
+
+/* Default intialization for Spring Beans is Eager, beans are intialized at start up, unless we explicitly add the @Lazy annotation.
+Using @Lazy annotation we configure the beans to be lazily initialized. Lazy-resolution proxy will be injected instead of the actual dependency.
+The bean is initialized when it is first made use of in the application. 
+However, eager initialization is recommended as we come across errors at startup instead of Run-time.  */
+@Component
+@Lazy
+class ClassB {
+    private ClassA classA;
+
+    public ClassB(ClassA classA) {
+        System.out.println("Some intialization logic");
+        this.classA = classA;
+    }
+
+    public void doSomething() {
+        System.out.println("Do something here!!");
+    }
+}
+
+@Configuration
+@ComponentScan
+public class LazyIntializationLauncherApplication {
+
+    public static void main(String[] args) {
+        try (var context = new AnnotationConfigApplicationContext(LazyIntializationLauncherApplication.class)) {
+
+            System.out.println("Context Initialization is completed");
+            
+            // You can see in the output that using @Lazy annotation
+            // initialization of the bean is done only after we add the next line to call the doSomething method.
+            // Bean intialization after the context initializagtion is completed and  not at the start up due to use of @Lazy annotation.
+            // In case of Eager initialization, any intialization errors wil prevent application from starting up.
+            // Whereas, in case of Lazy initialization errors will result in runtime exceptions.
+            context.getBean(ClassB.class).doSomething();
+        }
+    }
+}

--- a/src/main/java/com/learningadventures/learnspringframework/examples/a3/BusinessCalculationService.java
+++ b/src/main/java/com/learningadventures/learnspringframework/examples/a3/BusinessCalculationService.java
@@ -2,9 +2,9 @@ package com.learningadventures.learnspringframework.examples.a3;
 
 import java.util.Arrays;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class BusinessCalculationService {
     private DataService dataService;
 

--- a/src/main/java/com/learningadventures/learnspringframework/examples/a3/MongoDbDataService.java
+++ b/src/main/java/com/learningadventures/learnspringframework/examples/a3/MongoDbDataService.java
@@ -1,9 +1,9 @@
 package com.learningadventures.learnspringframework.examples.a3;
 
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-@Component
+@Repository
 @Primary
 public class MongoDbDataService implements DataService {
 

--- a/src/main/java/com/learningadventures/learnspringframework/examples/a3/MySQLDataService.java
+++ b/src/main/java/com/learningadventures/learnspringframework/examples/a3/MySQLDataService.java
@@ -1,8 +1,8 @@
 package com.learningadventures.learnspringframework.examples.a3;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-@Component
+@Repository
 public class MySQLDataService implements DataService {
 
     @Override

--- a/src/main/java/com/learningadventures/learnspringframework/examples/a4/BeanScopesLauncherApplication.java
+++ b/src/main/java/com/learningadventures/learnspringframework/examples/a4/BeanScopesLauncherApplication.java
@@ -1,0 +1,37 @@
+package com.learningadventures.learnspringframework.examples.a4;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+class NormalClass {
+
+}
+
+@Scope(value=ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Component
+class PrototypeClass {
+
+}
+
+@Configuration
+@ComponentScan
+public class BeanScopesLauncherApplication {
+
+    public static void main(String[] args) {
+        try (var context = new AnnotationConfigApplicationContext(BeanScopesLauncherApplication.class)) {
+            System.out.println(context.getBean(NormalClass.class));
+            System.out.println(context.getBean(NormalClass.class));
+            
+            System.out.println(context.getBean(PrototypeClass.class));
+            System.out.println(context.getBean(PrototypeClass.class));
+            System.out.println(context.getBean(PrototypeClass.class));
+        }
+    }    
+}


### PR DESCRIPTION
- Refactored real world example to use more specific stereotype annotations ```@Service, @Repository``` instead of general ```@Component``` annotation
- Added code to better understand Spring Bean Scopes ```@Singleton and @Prototype```
- Yet to practice Spring Bean Scope applicable **only** for web-aware Spring Application Context when I create a Spring Boot web application
    * Request
    * Session
    *  Application
    * Websocket
- Also, learned about Lazy and Eager Initialization and added example code for hands on learning. 
- By default Spring does Eager initialization unless stated explicitly by using ```@Lazy``` annotation. Recommended to use Eager initialization to catch any errors during application start up.